### PR TITLE
fix: disable release on pull request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,6 @@ name: Release
 on:
   push:
     branches: ["release"]
-  pull_request:
-    branches: ["release"]
 
 jobs:
   build:


### PR DESCRIPTION
Release action should not run before merged